### PR TITLE
Skru av autentisering før requests blir proxyet

### DIFF
--- a/src/main/java/no/nav/pto_proxy/config/FilterConfig.java
+++ b/src/main/java/no/nav/pto_proxy/config/FilterConfig.java
@@ -1,7 +1,6 @@
 package no.nav.pto_proxy.config;
 
 import no.nav.common.auth.context.UserRole;
-import no.nav.common.auth.oidc.filter.OidcAuthenticationFilter;
 import no.nav.common.auth.oidc.filter.OidcAuthenticatorConfig;
 import no.nav.common.log.LogFilter;
 import no.nav.pto_proxy.utils.ProxyCorsConfigSource;
@@ -11,7 +10,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.filter.CorsFilter;
 
 import static no.nav.common.auth.Constants.AZURE_AD_B2C_ID_TOKEN_COOKIE_NAME;
-import static no.nav.common.auth.oidc.filter.OidcAuthenticator.fromConfigs;
 import static no.nav.common.utils.EnvironmentUtils.isDevelopment;
 import static no.nav.common.utils.EnvironmentUtils.requireApplicationName;
 
@@ -44,17 +42,17 @@ public class FilterConfig {
         return registration;
     }
 
-    @Bean
-    public FilterRegistrationBean authenticationFilterRegistrationBean(EnvironmentProperties properties) {
-        FilterRegistrationBean<OidcAuthenticationFilter> registration = new FilterRegistrationBean<>();
-        OidcAuthenticationFilter authenticationFilter = new OidcAuthenticationFilter(
-                fromConfigs(loginserviceIdportenConfig(properties))
-        );
-
-        registration.setFilter(authenticationFilter);
-        registration.setOrder(3);
-        registration.addUrlPatterns("/proxy/*");
-        return registration;
-    }
+//    @Bean
+//    public FilterRegistrationBean authenticationFilterRegistrationBean(EnvironmentProperties properties) {
+//        FilterRegistrationBean<OidcAuthenticationFilter> registration = new FilterRegistrationBean<>();
+//        OidcAuthenticationFilter authenticationFilter = new OidcAuthenticationFilter(
+//                fromConfigs(loginserviceIdportenConfig(properties))
+//        );
+//
+//        registration.setFilter(authenticationFilter);
+//        registration.setOrder(3);
+//        registration.addUrlPatterns("/proxy/*");
+//        return registration;
+//    }
 
 }


### PR DESCRIPTION
Alle baksystemer har allerde bra nok autentisering, så det skal ikke være nødvendig med en ekstra sjekk i pto-proxy. I tillegg så vil noen av tjenestene ikke trenge autentisering som f.eks frontendlogger og pto-unleash.